### PR TITLE
vthunder plumbing hooks runs

### DIFF
--- a/a10_neutron_lbaas/a10_config.py
+++ b/a10_neutron_lbaas/a10_config.py
@@ -185,7 +185,6 @@ class A10Config(object):
             instance = models.A10DeviceInstance.find_by_device_name(device_name, db_session)
             if instance is not None:
                 self._devices[device_name] = dict(instance)
-                self._devices[device_name]['host'] = instance.ip_address
                 return self._devices[device_name]
         return None
 

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
@@ -46,12 +46,12 @@ def upgrade():
         sa.Column('v_method', sa.String(32), nullable=False),
         sa.Column('shared_partition', sa.String(1024), nullable=False),
         sa.Column('use_float', sa.Boolean(), nullable=False),
-        sa.Column('default_virtual_server_vrid', sa.Integer, nullable=False),
+        sa.Column('default_virtual_server_vrid', sa.Integer, nullable=True),
         sa.Column('ipinip', sa.Boolean(), nullable=False),
         sa.Column('write_memory', sa.Boolean(), nullable=False),
 
         sa.Column('nova_instance_id', sa.String(36), nullable=False),
-        sa.Column('ip_address', sa.String(255))
+        sa.Column('host', sa.String(255))
     )
     op.create_table(
         'a10_slbs',
@@ -68,6 +68,6 @@ def upgrade():
 
 
 def downgrade():
-    # op.drop_table('a10_slbs')
+    op.drop_table('a10_slbs')
     op.drop_table('a10_device_instances')
     pass

--- a/a10_neutron_lbaas/db/models.py
+++ b/a10_neutron_lbaas/db/models.py
@@ -95,12 +95,12 @@ class A10DeviceInstance(A10BaseMixin, Base):
     v_method = sa.Column(sa.String(32), nullable=False)
     shared_partition = sa.Column(sa.String(1024), nullable=False)
     use_float = sa.Column(sa.Boolean(), nullable=False)
-    default_virtual_server_vrid = sa.Column(sa.Integer, nullable=False)
+    default_virtual_server_vrid = sa.Column(sa.Integer, nullable=True)
     ipinip = sa.Column(sa.Boolean(), nullable=False)
     write_memory = sa.Column(sa.Boolean(), nullable=False)
 
     nova_instance_id = sa.Column(sa.String(36), nullable=True)
-    ip_address = sa.Column(sa.String(255), nullable=False)
+    host = sa.Column(sa.String(255), nullable=False)
 
     # TODO(dougwig) -- later - reference to scheduler, or capacity, or?
     # TODO(dougwig) -- later - should add state enum here

--- a/a10_neutron_lbaas/plumbing_hooks.py
+++ b/a10_neutron_lbaas/plumbing_hooks.py
@@ -173,11 +173,13 @@ class VThunderPlumbingHooks(PlumbingHooks):
         from a10_neutron_lbaas.etc import defaults
         device_config = {}
         for key in vth:
+            if key in ['status', 'ha_sync_list']:
+                continue
             if key in defaults.DEVICE_REQUIRED_FIELDS or key in defaults.DEVICE_OPTIONAL_DEFAULTS:
                 device_config[key] = vth[key]
         device_config.update({
+            'tenant_id': tenant_id,
             'nova_instance_id': instance['nova_instance_id'],
-            'host': instance['ip_address'],
             'name': instance['name']
         })
 
@@ -187,6 +189,7 @@ class VThunderPlumbingHooks(PlumbingHooks):
 
         if root_id is not None:
             models.A10SLB.create_and_save(
+                tenant_id=tenant_id,
                 device_name=device_config['name'],
                 loadbalancer_id=root_id,
                 db_session=db_session)


### PR DESCRIPTION
A10DeviceInstance: renamed ip_address to host to match device_config, made vrid nullable. vthunder plumbing hooks runs all the way through now
